### PR TITLE
Add logout functionality to Sidebar component

### DIFF
--- a/src/shared/component/cms/SidebarCMS.tsx
+++ b/src/shared/component/cms/SidebarCMS.tsx
@@ -11,11 +11,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/shared/component/ui/sidebar";
+import { useLogoutMutation } from "@/shared/repository/login/query";
 import Image from "next/image";
 import Link from "next/link";
+import { LogOut } from "lucide-react";
 
 const SidebarCMS = () => {
   const pathname = usePathname();
+  const { mutate: logout, isPending: isLogoutPending } = useLogoutMutation();
 
   return (
     <Sidebar
@@ -91,6 +94,17 @@ const SidebarCMS = () => {
                 >
                   Monitoring Pesanan
                 </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+
+            <SidebarMenuItem className="mt-2 pt-2">
+              <SidebarMenuButton
+                onClick={() => logout()}
+                disabled={isLogoutPending}
+                className="cursor-pointer rounded-[12px] bg-green-500 text-white transition-colors duration-200 hover:bg-green-600 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <LogOut className="size-4" />
+                <span>{isLogoutPending ? "Memproses..." : "Logout"}</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>

--- a/src/shared/component/mitra/SidebarMitra.tsx
+++ b/src/shared/component/mitra/SidebarMitra.tsx
@@ -11,11 +11,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/shared/component/ui/sidebar";
+import { useLogoutMutation } from "@/shared/repository/login/query";
 import Image from "next/image";
 import Link from "next/link";
+import { LogOut } from "lucide-react";
 
 const SidebarCMS = () => {
   const pathname = usePathname();
+  const { mutate: logout, isPending: isLogoutPending } = useLogoutMutation();
 
   return (
     <Sidebar
@@ -91,6 +94,17 @@ const SidebarCMS = () => {
                 >
                   Customer Service
                 </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+
+            <SidebarMenuItem className="mt-2 pt-2">
+              <SidebarMenuButton
+                onClick={() => logout()}
+                disabled={isLogoutPending}
+                className="cursor-pointer rounded-[12px] bg-green-500 text-white transition-colors duration-200 hover:bg-green-600 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <LogOut className="size-4" />
+                <span>{isLogoutPending ? "Memproses..." : "Logout"}</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>


### PR DESCRIPTION
This pull request adds a logout button to both the CMS and Mitra sidebars, allowing users to log out directly from the sidebar. The button provides visual feedback while the logout process is pending and uses a consistent design with an icon and loading text.

**Sidebar enhancements:**

* Added a logout button to the `SidebarCMS` component, utilizing `useLogoutMutation` for logout functionality and providing a loading state with the text "Memproses..." when the logout is in progress. The button includes a logout icon (`LogOut` from `lucide-react`) and is styled for clear user feedback. [[1]](diffhunk://#diff-2a0e7099de3aae16b2472be757f5c2a00b5f5c7477f3d2c13e08ac19e42caa30R14-R21) [[2]](diffhunk://#diff-2a0e7099de3aae16b2472be757f5c2a00b5f5c7477f3d2c13e08ac19e42caa30R99-R109)
* Added the same logout button to the `SidebarMitra` component, with identical functionality, styling, and loading state handling as in the CMS sidebar. [[1]](diffhunk://#diff-be71348c393f57fdc27a20f1a3723d3551bb0a3745ddbf1820d90bad6985f8b0R14-R21) [[2]](diffhunk://#diff-be71348c393f57fdc27a20f1a3723d3551bb0a3745ddbf1820d90bad6985f8b0R99-R109)