### PR TITLE
Add logout functionality and session refresh features

### DIFF
--- a/src/feature/sppg/cari/components/ScanModal.tsx
+++ b/src/feature/sppg/cari/components/ScanModal.tsx
@@ -1,9 +1,41 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { Card } from "@/shared/component/ui/card";
 import Image from "next/image";
 import { Button } from "@/shared/component/ui/button";
 import { RotateCw } from "lucide-react";
 
+const REDIRECT_DELAY_MS = 5000;
+const START_SECONDS = 60;
+
 const ScanModal = () => {
+  const router = useRouter();
+  const [secondsLeft, setSecondsLeft] = useState(START_SECONDS);
+  const [sessionKey, setSessionKey] = useState(0);
+
+  useEffect(() => {
+    const intervalId = window.setInterval(() => {
+      setSecondsLeft((prev) => Math.max(prev - 1, 0));
+    }, 1000);
+
+    const timeoutId = window.setTimeout(() => {
+      router.push("/sppg/pembayaran-berhasil");
+    }, REDIRECT_DELAY_MS);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.clearTimeout(timeoutId);
+    };
+  }, [router, sessionKey]);
+
+  const countdownLabel = useMemo(() => {
+    const minutes = String(Math.floor(secondsLeft / 60)).padStart(2, "0");
+    const seconds = String(secondsLeft % 60).padStart(2, "0");
+    return `${minutes}.${seconds}`;
+  }, [secondsLeft]);
+
   return (
     <div className="w-full rounded-[28px] bg-white py-8">
       <div className="flex items-start pb-10">
@@ -18,18 +50,12 @@ const ScanModal = () => {
       </div>
       <div className="flex flex-col items-center justify-center gap-3 md:gap-6">
         <Card className="w-full max-w-[80%] rounded-2xl border-4 border-green-900 p-0 md:max-w-[60%]">
-          <Image
-            src={"/images/QRIS-1.png"}
-            alt={"qris"}
-            width={1000}
-            height={1000}
-          />
+          <Image src={"/images/QRIS-1.png"} alt={"qris"} width={1000} height={1000} />
         </Card>
         <h2 className="text-[10px] font-medium text-green-500 md:text-xl">
           Kadaluarsa dalam
           <span className="text-[10px] font-bold text-green-700 md:text-xl">
-            {" "}
-            00.46
+            {` ${countdownLabel}`}
           </span>
         </h2>
         <div className="rounded-[40px] bg-green-50 px-8 py-2">
@@ -37,7 +63,14 @@ const ScanModal = () => {
             Order ID: #ORD-MBG-7729
           </p>
         </div>
-        <Button className="mt-3 flex w-full max-w-[60%] cursor-pointer items-center justify-center gap-1 rounded-[12px] border border-green-600 bg-orange-600 text-[8px] font-bold text-orange-50 md:mt-0 md:max-w-[90%] md:gap-4 md:border-2 md:py-6 md:text-xl">
+        <Button
+          type="button"
+          onClick={() => {
+            setSecondsLeft(START_SECONDS);
+            setSessionKey((prev) => prev + 1);
+          }}
+          className="mt-3 flex w-full max-w-[60%] cursor-pointer items-center justify-center gap-1 rounded-[12px] border border-green-600 bg-orange-600 text-[8px] font-bold text-orange-50 md:mt-0 md:max-w-[90%] md:gap-4 md:border-2 md:py-6 md:text-xl"
+        >
           Segarkan status <RotateCw className="p-1 md:p-0" />
         </Button>
       </div>

--- a/src/shared/component/cms/NavbarCMS.tsx
+++ b/src/shared/component/cms/NavbarCMS.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useLogoutMutation } from "@/shared/repository/login/query";
 
 const NavLink = [
   { name: "Ringkasan Dashboard", href: "/admin/dashboard" },
@@ -13,6 +14,7 @@ const NavLink = [
 
 const NavbarCMS = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { mutate: logout, isPending: isLoggingOut } = useLogoutMutation();
 
   return (
     <div className="md:hidden">
@@ -89,6 +91,18 @@ const NavbarCMS = () => {
               {item.name}
             </Link>
           ))}
+
+          <button
+            type="button"
+            disabled={isLoggingOut}
+            onClick={() => {
+              setIsOpen(false);
+              logout();
+            }}
+            className="cursor-pointer rounded-[12px] border border-white px-4 py-2 text-[16px] font-bold text-white transition hover:bg-white hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoggingOut ? "Memproses..." : "Logout"}
+          </button>
         </div>
       </div>
     </div>

--- a/src/shared/component/mitra/NavbarMitra.tsx
+++ b/src/shared/component/mitra/NavbarMitra.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useLogoutMutation } from "@/shared/repository/login/query";
 
 const NavLink = [
   { name: "Ringkasan Dashboard", href: "/mitra/dashboard" },
@@ -13,6 +14,7 @@ const NavLink = [
 
 const NavbarMitra = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { mutate: logout, isPending: isLoggingOut } = useLogoutMutation();
 
   return (
     <div className="md:hidden">
@@ -89,6 +91,18 @@ const NavbarMitra = () => {
               {item.name}
             </Link>
           ))}
+
+          <button
+            type="button"
+            disabled={isLoggingOut}
+            onClick={() => {
+              setIsOpen(false);
+              logout();
+            }}
+            className="cursor-pointer rounded-[12px] border border-white px-4 py-2 text-[16px] font-bold text-white transition hover:bg-white hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoggingOut ? "Memproses..." : "Logout"}
+          </button>
         </div>
       </div>
     </div>

--- a/src/shared/component/ui/sidebar.tsx
+++ b/src/shared/component/ui/sidebar.tsx
@@ -81,18 +81,15 @@ function SidebarProvider({
         _setOpen(openState);
       }
 
-      // This sets the cookie to keep the sidebar state.
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
     [setOpenProp, open],
   );
 
-  // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
   }, [isMobile, setOpen, setOpenMobile]);
 
-  // Adds a keyboard shortcut to toggle the sidebar.
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (
@@ -108,8 +105,6 @@ function SidebarProvider({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [toggleSidebar]);
 
-  // We add a state so that we can do data-state="expanded" or "collapsed".
-  // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? "expanded" : "collapsed";
 
   const contextValue = React.useMemo<SidebarContextProps>(


### PR DESCRIPTION
This pull request introduces two main improvements: a new countdown and auto-redirect feature to the `ScanModal` component, and the addition of a logout button to both the CMS and Mitra mobile navigation bars. Additionally, minor code cleanup was performed in the sidebar component.

**Feature enhancements:**

* Added a countdown timer and auto-redirect to the `ScanModal` component. The modal now displays a live countdown and automatically redirects to the success page after a delay. A "refresh" button allows users to restart the countdown. (`src/feature/sppg/cari/components/ScanModal.tsx`) [[1]](diffhunk://#diff-8ef17598cf89ebba3200a903528badb92f4810e1de13061bd29b7846453d54d8R1-R38) [[2]](diffhunk://#diff-8ef17598cf89ebba3200a903528badb92f4810e1de13061bd29b7846453d54d8L21-R73)

**Navigation improvements:**

* Added a logout button to the mobile navigation bar in the CMS interface, using the `useLogoutMutation` hook to handle logout and display a loading state. (`src/shared/component/cms/NavbarCMS.tsx`) [[1]](diffhunk://#diff-4a48f54e287333918e1c8a5656ebc3a4b205abaaec8881e088415a078837fd5eR6) [[2]](diffhunk://#diff-4a48f54e287333918e1c8a5656ebc3a4b205abaaec8881e088415a078837fd5eR17) [[3]](diffhunk://#diff-4a48f54e287333918e1c8a5656ebc3a4b205abaaec8881e088415a078837fd5eR94-R105)
* Added a logout button to the mobile navigation bar in the Mitra interface, with similar functionality and loading state as the CMS logout. (`src/shared/component/mitra/NavbarMitra.tsx`) [[1]](diffhunk://#diff-f825717cb730bb255e8c3f49ce35a242e75c1622ffc33afe88f59c2ba14896e0R6) [[2]](diffhunk://#diff-f825717cb730bb255e8c3f49ce35a242e75c1622ffc33afe88f59c2ba14896e0R17) [[3]](diffhunk://#diff-f825717cb730bb255e8c3f49ce35a242e75c1622ffc33afe88f59c2ba14896e0R94-R105)

**Code cleanup:**

* Removed outdated comments from the sidebar provider for improved code clarity. (`src/shared/component/ui/sidebar.tsx`) [[1]](diffhunk://#diff-d030409896fa498f76bc53e643fb7d4362ed1b7a72211936397c08fb193539abL84-L95) [[2]](diffhunk://#diff-d030409896fa498f76bc53e643fb7d4362ed1b7a72211936397c08fb193539abL111-L112)